### PR TITLE
fixed something

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -4,26 +4,41 @@ using Microsoft.Xna.Framework;
 
 namespace Celeste.Mod.Entities {
     /// <summary>
+    /// Base type of <see cref="EntityCollider{T}"/>.
+    /// In case you don't know the exact type.
+    /// </summary>
+    [Tracked(false)]
+    public abstract class EntityCollider : Component {
+        public abstract Type EntityType { get; }
+
+        public Action<Entity> OnEntityAction { get; protected set; }
+
+        public Collider Collider;
+
+        public EntityCollider(bool active, bool visible) : base(active, visible) {
+        }
+    }
+    /// <summary>
     /// Allows for Collision with any type of entity in the game, similar to a PlayerCollider or PufferCollider.
     /// Performs the Action provided on collision. 
     /// </summary>
     /// <typeparam name="T">The specific type of Entity this component should try to collide with</typeparam>
-    [Tracked(false)]
-    public class EntityCollider<T> : Component where T : Entity {
+    public class EntityCollider<T> : EntityCollider where T : Entity {
         /// <summary>
         /// Provides a simple way to know the Entity type of the specific Collider
         /// </summary>
-        public Type EntityType => typeof(T);
+        public override Type EntityType => typeof(T);
 
         /// <summary>
         /// The Action invoked on Collision, with the Entity collided with passed as a parameter
         /// </summary>
-        public Action<T> OnEntityAction;
-
-        public Collider Collider;
+        public new Action<T> OnEntityAction;
 
         public EntityCollider(Action<T> onEntityAction, Collider collider = null)
             : base(active: true, visible: true) {
+            base.OnEntityAction = e => {
+                OnEntityAction((T) e);
+            };
             OnEntityAction = onEntityAction;
             Collider = collider;
         }
@@ -35,6 +50,10 @@ namespace Celeste.Mod.Entities {
                 if (!Scene.Tracker.IsEntityTracked<T>()) {
                     patch_Tracker.AddTypeToTracker(typeof(T));
                 }
+                if (!Scene.Tracker.IsComponentTracked<EntityCollider<T>>()) {
+                    patch_Tracker.AddTypeToTracker(typeof(EntityCollider<T>));
+                    patch_Tracker.AddTypeToTracker(typeof(EntityCollider<T>), typeof(EntityCollider));
+                }
                 (Scene.Tracker as patch_Tracker).Refresh();
             }
         }
@@ -42,6 +61,10 @@ namespace Celeste.Mod.Entities {
         public override void EntityAdded(Scene scene) {
             if (!scene.Tracker.IsEntityTracked<T>()) {
                 patch_Tracker.AddTypeToTracker(typeof(T));
+            }
+            if (!scene.Tracker.IsComponentTracked<EntityCollider<T>>()) {
+                patch_Tracker.AddTypeToTracker(typeof(EntityCollider<T>));
+                patch_Tracker.AddTypeToTracker(typeof(EntityCollider<T>), typeof(EntityCollider));
             }
             base.EntityAdded(scene);
         }

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -11,7 +11,7 @@ namespace Celeste.Mod.Entities {
     public abstract class EntityColliderByComponent : Component {
         public abstract Type ComponentType { get; }
 
-        public Action<Component> OnComponentAction { get; protected set; }
+        public virtual Action<Component> OnComponentAction => throw new NotImplementedException();
 
         public Collider Collider;
 
@@ -35,11 +35,13 @@ namespace Celeste.Mod.Entities {
         /// </summary>
         public new Action<T> OnComponentAction;
 
+        [MonoMod.NotPatchEntityColliderMakeVirtual]
+        public Action<Component> get_OnEntityAction() => c => {
+            OnComponentAction((T) c);
+        };
+
         public EntityColliderByComponent(Action<T> onComponentAction, Collider collider = null)
             : base(active: true, visible: true) {
-            base.OnComponentAction = c => {
-                OnComponentAction((T) c);
-            };
             OnComponentAction = onComponentAction;
             Collider = collider;
         }


### PR DESCRIPTION
generic type can't be tracked correctly, add them to tracker manually.
tracker can only track `EntityCollider<?>` and cannot track any of the `EntityCollider<T>`.

`EntityType` is meaningless, as you can't use `EntityCollider<T>.EntityType` without knowing T in code.
put it to a base class.
I just noticed that `EntityCollider<?>` is valid in Java. Then i know why you are doing this. 
*welcome to the csharp™.*

use monomod black magic to add two fields with conflicting names. feel free to revert it as it's black magic anyway.

use "version" to determine if it's outdated. (you can't set all scene's trackers to unrefreshed without track them.)
